### PR TITLE
OBS-31: Deduplicar links al ingerir feeds

### DIFF
--- a/migrations/20240610193812_make_feed_item_link_unique.mjs
+++ b/migrations/20240610193812_make_feed_item_link_unique.mjs
@@ -1,0 +1,11 @@
+export const up = async (knex) => {
+  return knex.schema.withSchema("public").alterTable("feedItems", (table) => {
+    table.unique("link");
+  });
+};
+
+export const down = async (knex) => {
+  return knex.schema.withSchema("public").alterTable("feedItems", (table) => {
+    table.dropUnique("link");
+  });
+};

--- a/src/data/feedItem.js
+++ b/src/data/feedItem.js
@@ -41,6 +41,15 @@ function removeHtmlTags(value) {
   return value.replace(/(<([^>]+)>)/ig, '');
 }
 
+export function extractUrlFromGoogleUrl(link) {
+  const url = new URL(link);
+  if (url.host === "www.google.com" && url.pathname === "/url" && url.searchParams.has("url")) {
+    return url.searchParams.get("url");
+  }
+
+  return link;
+}
+
 export function feedItemFromRss(rssFeed, rssItem) {
   return {
     feedId: rssFeed.link,
@@ -49,7 +58,7 @@ export function feedItemFromRss(rssFeed, rssItem) {
     publishedAt: rssItem.pubDate,
     feedItemKey: rssItem.id,
     title: removeHtmlTags(rssItem.title),
-    link: rssItem.link
+    link: extractUrlFromGoogleUrl(rssItem.link),
   };
 }
 
@@ -60,7 +69,7 @@ export async function insertNewFeedItems(feedItems) {
 
   await feedItemsTable()
     .insert(feedItems)
-    .onConflict("feedItemKey").ignore();
+    .onConflict().ignore();
 }
 
 export function fetchFeedItems({ status, limit, start }) {


### PR DESCRIPTION
Relacionado a https://observatorioaqsnv.atlassian.net/browse/OBS-31

Sumario de cambios:

1. Agrega un constraint en la db para que no podamos duplicar exactamente el mismo link en dos feeds distintos.
2. Quita el unique constraint en la clausula de on conflict para que si lo que esta duplicado es el `feedItemKey` o el `link` ignore la feed que entra segunda.
3. Los links que nos vienen de google alerts vienen con una url propia de google que encodea la url objetivo por cuestiones de impression tracking. Esta url no devuelve un redirect, sino que hace client side redirection para llevar al usuario al link final. Este PR agrega un preprocesamiento al link que parsea esta url de google y extrae la url original a la que va el link. Este preprocesamiento es super conservador porque la estructura de esta url no esta documentada, asi que tecnicamente podria cambiar, por lo que solo preprocesa si todos los assumptions de la estructura de esta url de google se dan.