### PR TITLE
OBK-20: Almacena el campo content snippet en nuestro feedItem

### DIFF
--- a/migrations/20240706102054_add_snippet_to_feed_items.mjs
+++ b/migrations/20240706102054_add_snippet_to_feed_items.mjs
@@ -1,0 +1,11 @@
+export const up = async (knex) => {
+  return knex.schema.withSchema("public").alterTable("feedItems", (table) => {
+    table.specificType("snippet", "varchar");
+  });
+};
+
+export const down = async (knex) => {
+  return knex.schema.withSchema("public").alterTable("feedItems", (table) => {
+    table.dropColumn("snippet");
+  });
+};

--- a/src/data/feedItem.js
+++ b/src/data/feedItem.js
@@ -14,6 +14,7 @@ const feedItemsQuery = () => feedItemsTable()
     publishedAt: "feedItems.publishedAt",
     title: "feedItems.title",
     link: "feedItems.link",
+    snippet: "feedItems.snippet",
     isDone: "feedItems.isDone",
     isIrrelevant: "feedItems.isIrrelevant",
     assignedUserId: "feedItems.assignedUserId",
@@ -62,6 +63,7 @@ export function feedItemFromRss(rssFeed, rssItem) {
     feedItemKey: rssItem.id,
     title: removeHtmlTags(rssItem.title),
     link: extractUrlFromGoogleUrl(rssItem.link),
+    snippet: rssItem.contentSnippet,
   };
 }
 

--- a/src/routers/feed.js
+++ b/src/routers/feed.js
@@ -91,6 +91,7 @@ router.operation({
         publishedAt: x.publishedAt,
         title: x.title,
         link: x.link,
+        contentSnippet: x.snippet,
         isDone: x.isDone,
         isIrrelevant: x.isIrrelevant,
         assignedUser: x.assignedUserId ? {


### PR DESCRIPTION
Relacionado con https://ahoraquesinosven.atlassian.net/browse/OBK-20

Sumario de cambios
* Agrega un campo `snippet` que almacena el texto que reporta google usó para matchear la noticia al feed. La idea es que quizas poemos incluir esa información en el frontend para que sea más fácil entender por qué alguna noticia matcheo.